### PR TITLE
Log only successful KV lookups

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,13 +17,13 @@ export default {
         try {
           const target = atob(encoded);
           response = Response.redirect(target, 302);
+          ctx.waitUntil(logRequest(env, slug, request, response));
         } catch (err) {
           response = redirectFallback(env);
         }
       }
     }
 
-    ctx.waitUntil(logRequest(env, slug, request, response));
     return response;
   }
 };


### PR DESCRIPTION
## Summary
- log requests only when a KV slug exists and decodes successfully

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d668c7cc8328aaa34c77e9c10a56