### PR TITLE
Ensure logging and configure default URLs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,10 @@ export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
     const slug = url.pathname.replace(/^\//, "");
-    if (slug && !/^[-\w]+$/.test(slug)) {
-      return redirectFallback(env);
-    }
-
     let response;
-    if (!slug) {
+    if (slug && !/^[-\w]+$/.test(slug)) {
+      response = redirectFallback(env);
+    } else if (!slug) {
       response = redirectFallback(env);
     } else {
       const encoded = await env.LINKS?.get(slug);
@@ -17,13 +15,13 @@ export default {
         try {
           const target = atob(encoded);
           response = Response.redirect(target, 302);
-          ctx.waitUntil(logRequest(env, slug, request, response));
         } catch (err) {
           response = redirectFallback(env);
         }
       }
     }
 
+    ctx.waitUntil(logRequest(env, slug, request, response));
     return response;
   }
 };

--- a/wrangler.json
+++ b/wrangler.json
@@ -9,4 +9,9 @@
       "id": "4730478eed524eabb055ba52ac573b4d"
     }
   ],
+  "vars": {
+    "LOG_ENDPOINT": "https://panel-local.polskilekarz.eu/cloudflare/link-clicks",
+    "FALLBACK_URL": "https://polskilekarz.eu"
+  }
 }
+


### PR DESCRIPTION
## Summary
- Log every request, including fallbacks, by deferring logging until after the response is chosen
- Add default LOG_ENDPOINT and FALLBACK_URL configuration in `wrangler.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7110ea1b88328b4ef01d91c09ddb1