### PR TITLE
Revert logging change while retaining default URLs

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -9,4 +9,9 @@
       "id": "4730478eed524eabb055ba52ac573b4d"
     }
   ],
+  "vars": {
+    "LOG_ENDPOINT": "https://panel-local.polskilekarz.eu/cloudflare/link-clicks",
+    "FALLBACK_URL": "https://polskilekarz.eu"
+  }
 }
+


### PR DESCRIPTION
## Summary
- Restore prior logging logic by triggering logs only for successful lookups
- Keep default LOG_ENDPOINT and FALLBACK_URL configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7110ea1b88328b4ef01d91c09ddb1