### PR TITLE
Log all requests with slug lookup status

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -9,4 +9,9 @@
       "id": "4730478eed524eabb055ba52ac573b4d"
     }
   ],
+  "vars": {
+    "LOG_ENDPOINT": "https://panel-local.polskilekarz.eu/cloudflare/link-clicks",
+    "FALLBACK_URL": "https://polskilekarz.eu"
+  }
 }
+


### PR DESCRIPTION
## Summary
- Log each request and whether its slug was found in KV without including the slug itself
- Configure default `LOG_ENDPOINT` and `FALLBACK_URL` values for consistent logging and fallback behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7110ea1b88328b4ef01d91c09ddb1