### PR TITLE
Store access logs in KV namespace

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -7,10 +7,13 @@
     {
       "binding": "LINKS",
       "id": "4730478eed524eabb055ba52ac573b4d"
+    },
+    {
+      "binding": "LOGS",
+      "id": "4e1e394c8aa4486a85025eecb9a40c1c"
     }
   ],
   "vars": {
-    "LOG_ENDPOINT": "https://panel-local.polskilekarz.eu/cloudflare/link-clicks",
     "FALLBACK_URL": "https://polskilekarz.eu"
   }
 }


### PR DESCRIPTION
## Summary
- adjust log key naming to drop the redundant `link-` prefix while keeping per-slug auto-incrementing IDs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4f0947d808328853465844d549bba