### PR TITLE
Store logs in link namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ When a slug is requested the worker looks up the corresponding entry, decodes th
 ## Features
 - **Simple redirects** – map `https://your.worker.dev/my-slug` to a long URL stored in KV.
 - **Fallback handling** – unknown or malformed slugs redirect to a default URL.
-- **Structured logging (optional)** – capture request/response metadata into a second KV namespace for later analysis, compressed with gzip to save space.
+- **Structured logging (optional)** – capture request/response metadata alongside links in the same KV namespace, compressed with gzip to save space.
 
 ## Prerequisites
 - [Wrangler](https://developers.cloudflare.com/workers/wrangler/install-and-update/) 3.x
 - A Cloudflare account with access to Workers and KV
 
 ## Configuration
-1. Create two KV namespaces (one for links, one for logs) and bind them in `wrangler.json` as `LINKS` and `LOGS`. Logging is optional; if you do not need it you can remove the `LOGS` binding.
+1. Create a KV namespace for links and bind it in `wrangler.json` as `LINKS`. Logging entries are stored in the same namespace under `slug:entries:<uuid>` keys, so no additional binding is required.
 2. Set the `FALLBACK_URL` variable to the URL you want users to see when a slug is missing or invalid.
 
 Update the placeholder IDs in `wrangler.json` with your actual namespace IDs:
@@ -21,8 +21,7 @@ Update the placeholder IDs in `wrangler.json` with your actual namespace IDs:
 ```json
 {
   "kv_namespaces": [
-    { "binding": "LINKS", "id": "<your-links-namespace-id>" },
-    { "binding": "LOGS", "id": "<your-logs-namespace-id>" }
+    { "binding": "LINKS", "id": "<your-links-namespace-id>" }
   ],
   "vars": {
     "FALLBACK_URL": "https://example.com"

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function goHome(env) {
 }
 
 async function sendLog(env, slug, request, res) {
-  if (!env.LOGS) return;
+  if (!env.LINKS) return;
   const payload = {
     slug,
     request: {
@@ -59,9 +59,9 @@ async function sendLog(env, slug, request, res) {
   };
 
   try {
-    const logKey = `${slug}:${uuidv7()}`;
+    const logKey = `${slug}:entries:${uuidv7()}`;
     const encoded = await compressToBase64(payload);
-    await env.LOGS.put(logKey, encoded);
+    await env.LINKS.put(logKey, encoded);
   } catch (err) {
     log('log-error', { err: err.message });
   }

--- a/wrangler.json
+++ b/wrangler.json
@@ -7,10 +7,6 @@
     {
       "binding": "LINKS",
       "id": "4730478eed524eabb055ba52ac573b4d"
-    },
-    {
-      "binding": "LOGS",
-      "id": "4e1e394c8aa4486a85025eecb9a40c1c"
     }
   ],
   "vars": {


### PR DESCRIPTION
## Summary
- write request/response log entries to the LINKS namespace using slug:entries:uuid keys
- remove the extra LOGS namespace binding and document the single-namespace setup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f758768258832884ca745d7f45f170